### PR TITLE
fix: avoid alloc using strings.IndexFunc instead

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,13 +1,13 @@
 package logf
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	stdlog "log"
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -294,7 +294,7 @@ func writeToBuf(buf *byteBuffer, key string, val any, lvl Level, color, space bo
 
 // escapeAndWriteString escapes the string if any unwanted chars are there.
 func escapeAndWriteString(buf *byteBuffer, s string) {
-	idx := bytes.IndexFunc([]byte(s), checkEscapingRune)
+	idx := strings.IndexFunc(s, checkEscapingRune)
 	if idx != -1 {
 		writeQuotedString(buf, s)
 		return


### PR DESCRIPTION
Uses strings.IndexFunc to avoid allocs.

After patching:
![post_fix_1](https://user-images.githubusercontent.com/952036/177277794-645bb0ae-7e0d-4239-8295-147175dc03c9.png)

Before patching:

![pre_fix_1](https://user-images.githubusercontent.com/952036/177277820-d9c2e73c-5046-4661-bae6-870222dc7120.png)



Benchstat:

```
name                      old time/op    new time/op    delta
NoField-8                    179ns ± 3%     176ns ± 3%     ~     (p=0.567 n=3+3)
OneField-8                   283ns ± 1%     306ns ± 4%     ~     (p=0.064 n=3+3)
ThreeFields-8                338ns ± 2%     373ns ± 5%  +10.41%  (p=0.044 n=3+3)
ErrorField-8                 381ns ±13%     345ns ± 3%     ~     (p=0.291 n=3+3)
HugePayload-8               1.11µs ± 6%    1.16µs ±22%     ~     (p=0.745 n=3+3)
ThreeFields_WithCaller-8     932ns ± 4%    1043ns ±14%     ~     (p=0.287 n=3+3)
NoField_WithColor-8          320ns ± 1%     320ns ±11%     ~     (p=0.978 n=3+3)
OneField_WithColor-8         441ns ± 9%     421ns ± 2%     ~     (p=0.414 n=3+3)
ThreeFields_WithColor-8      569ns ±19%     519ns ± 2%     ~     (p=0.456 n=3+3)
ErrorField_WithColor-8       500ns ±10%     465ns ± 2%     ~     (p=0.317 n=3+3)
HugePayload_WithColor-8     1.24µs ± 7%    1.38µs ±22%     ~     (p=0.450 n=3+3)

name                      old alloc/op   new alloc/op   delta
NoField-8                    0.00B          0.00B          ~     (zero variance)
OneField-8                    336B ± 0%      336B ± 0%     ~     (zero variance)
ThreeFields-8                 336B ± 0%      336B ± 0%     ~     (zero variance)
ErrorField-8                  368B ± 0%      368B ± 0%     ~     (zero variance)
HugePayload-8                 919B ± 0%      919B ± 0%     ~     (zero variance)
ThreeFields_WithCaller-8      656B ± 0%      656B ± 0%     ~     (zero variance)
NoField_WithColor-8          0.00B          0.00B          ~     (zero variance)
OneField_WithColor-8          336B ± 0%      336B ± 0%     ~     (zero variance)
ThreeFields_WithColor-8       336B ± 0%      336B ± 0%     ~     (zero variance)
ErrorField_WithColor-8        368B ± 0%      368B ± 0%     ~     (zero variance)
HugePayload_WithColor-8       919B ± 0%      919B ± 0%     ~     (p=0.423 n=3+3)

name                      old allocs/op  new allocs/op  delta
NoField-8                     0.00           0.00          ~     (zero variance)
OneField-8                    2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ThreeFields-8                 2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ErrorField-8                  4.00 ± 0%      4.00 ± 0%     ~     (zero variance)
HugePayload-8                 3.00 ± 0%      3.00 ± 0%     ~     (zero variance)
ThreeFields_WithCaller-8      7.00 ± 0%      7.00 ± 0%     ~     (zero variance)
NoField_WithColor-8           0.00           0.00          ~     (zero variance)
OneField_WithColor-8          2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ThreeFields_WithColor-8       2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ErrorField_WithColor-8        4.00 ± 0%      4.00 ± 0%     ~     (zero variance)
HugePayload_WithColor-8       3.00 ± 0%      3.00 ± 0%     ~     (zero variance)
```