### PR TITLE
draft: new field input format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ data/
 dist/
 .vscode/
 coverage.txt
+
+*.png

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -27,7 +27,7 @@ func BenchmarkOneField(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			logger.WithFields(logf.Fields{"stack": "testing"}).Info("hello world")
+			logger.WithFields(logf.F{"stack", "testing"}).Info("hello world")
 		}
 	})
 }
@@ -40,11 +40,11 @@ func BenchmarkThreeFields(b *testing.B) {
 
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			logger.WithFields(logf.Fields{
-				"component": "api",
-				"method":    "GET",
-				"bytes":     1 << 18,
-			}).Info("request completed")
+			logger.WithFields([]logf.F{
+				{"component", "api"},
+				{"method", "GET"},
+				{"bytes", 1 << 18},
+			}...).Info("request completed")
 		}
 	})
 }
@@ -72,18 +72,18 @@ func BenchmarkHugePayload(b *testing.B) {
 
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			logger.WithFields(logf.Fields{
-				"id":                 11,
-				"title":              "perfume Oil",
-				"description":        "Mega Discount, Impression of A...",
-				"price":              13,
-				"discountPercentage": 8.4,
-				"rating":             4.26,
-				"stock":              65,
-				"brand":              "Impression of Acqua Di Gio",
-				"category":           "fragrances",
-				"thumbnail":          "https://dummyjson.com/image/i/products/11/thumbnail.jpg",
-			}).Info("fetched details")
+			logger.WithFields([]logf.F{
+				{"id", 11},
+				{"title", "perfume Oil"},
+				{"description", "Mega Discount, Impression of A..."},
+				{"price", 13},
+				{"discountPercentage", 8.4},
+				{"rating", 4.26},
+				{"stock", 65},
+				{"brand", "Impression of Acqua Di Gio"},
+				{"category", "fragrances"},
+				{"thumbnail", "https://dummyjson.com/image/i/products/11/thumbnail.jpg"},
+			}...).Info("fetched details")
 		}
 	})
 }
@@ -97,11 +97,11 @@ func BenchmarkThreeFields_WithCaller(b *testing.B) {
 
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			logger.WithFields(logf.Fields{
-				"component": "api",
-				"method":    "GET",
-				"bytes":     1 << 18,
-			}).Info("request completed")
+			logger.WithFields([]logf.F{
+				{"component", "api"},
+				{"method", "GET"},
+				{"bytes", 1 << 18},
+			}...).Info("request completed")
 		}
 	})
 }
@@ -128,7 +128,7 @@ func BenchmarkOneField_WithColor(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			logger.WithFields(logf.Fields{"stack": "testing"}).Info("hello world")
+			logger.WithFields(logf.F{"stack", "testing"}).Info("hello world")
 		}
 	})
 }
@@ -142,11 +142,11 @@ func BenchmarkThreeFields_WithColor(b *testing.B) {
 
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			logger.WithFields(logf.Fields{
-				"component": "api",
-				"method":    "GET",
-				"bytes":     1 << 18,
-			}).Info("request completed")
+			logger.WithFields([]logf.F{
+				{"component", "api"},
+				{"method", "GET"},
+				{"bytes", 1 << 18},
+			}...).Info("request completed")
 		}
 	})
 }
@@ -176,18 +176,18 @@ func BenchmarkHugePayload_WithColor(b *testing.B) {
 
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			logger.WithFields(logf.Fields{
-				"id":                 11,
-				"title":              "perfume Oil",
-				"description":        "Mega Discount, Impression of A...",
-				"price":              13,
-				"discountPercentage": 8.4,
-				"rating":             4.26,
-				"stock":              65,
-				"brand":              "Impression of Acqua Di Gio",
-				"category":           "fragrances",
-				"thumbnail":          "https://dummyjson.com/image/i/products/11/thumbnail.jpg",
-			}).Info("fetched details")
+			logger.WithFields([]logf.F{
+				{"id", 11},
+				{"title", "perfume Oil"},
+				{"description", "Mega Discount, Impression of A..."},
+				{"price", 13},
+				{"discountPercentage", 8.4},
+				{"rating", 4.26},
+				{"stock", 65},
+				{"brand", "Impression of Acqua Di Gio"},
+				{"category", "fragrances"},
+				{"thumbnail", "https://dummyjson.com/image/i/products/11/thumbnail.jpg"},
+			}...).Info("fetched details")
 		}
 	})
 }

--- a/field_logger.go
+++ b/field_logger.go
@@ -3,32 +3,32 @@ package logf
 import "os"
 
 type FieldLogger struct {
-	fields Fields
+	fields []F
 	logger *Logger
 }
 
 func (l *FieldLogger) Debug(msg string) {
-	l.logger.handleLog(msg, DebugLevel, l.fields)
+	l.logger.handleLog(msg, DebugLevel, l.fields...)
 }
 
 // Info emits a info log line.
 func (l *FieldLogger) Info(msg string) {
-	l.logger.handleLog(msg, InfoLevel, l.fields)
+	l.logger.handleLog(msg, InfoLevel, l.fields...)
 }
 
 // Warn emits a warning log line.
 func (l *FieldLogger) Warn(msg string) {
-	l.logger.handleLog(msg, WarnLevel, l.fields)
+	l.logger.handleLog(msg, WarnLevel, l.fields...)
 }
 
 // Error emits an error log line.
 func (l *FieldLogger) Error(msg string) {
-	l.logger.handleLog(msg, ErrorLevel, l.fields)
+	l.logger.handleLog(msg, ErrorLevel, l.fields...)
 }
 
 // Fatal emits a fatal level log line.
 // It aborts the current program with an exit code of 1.
 func (l *FieldLogger) Fatal(msg string) {
-	l.logger.handleLog(msg, ErrorLevel, l.fields)
+	l.logger.handleLog(msg, ErrorLevel, l.fields...)
 	os.Exit(1)
 }

--- a/log.go
+++ b/log.go
@@ -1,13 +1,13 @@
 package logf
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	stdlog "log"
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -294,7 +294,7 @@ func writeToBuf(buf *byteBuffer, key string, val any, lvl Level, color, space bo
 
 // escapeAndWriteString escapes the string if any unwanted chars are there.
 func escapeAndWriteString(buf *byteBuffer, s string) {
-	idx := bytes.IndexFunc([]byte(s), checkEscapingRune)
+	idx := strings.IndexFunc(s, checkEscapingRune)
 	if idx != -1 {
 		writeQuotedString(buf, s)
 		return

--- a/log_test.go
+++ b/log_test.go
@@ -58,11 +58,11 @@ func TestLogFormat(t *testing.T) {
 	buf.Reset()
 
 	// Log with field.
-	fields := Fields{
-		"stack": "testing",
+	fields := F{
+		"stack", "testing",
 	}
 	fl := l.WithFields(fields)
-	assert.Equal(t, fl.fields, fields)
+	assert.Equal(t, fl.fields, []F{fields})
 	fl.Warn("testing fields")
 	assert.Contains(t, buf.String(), `level=warn message="testing fields" stack=testing`, "warning log")
 	buf.Reset()
@@ -71,7 +71,7 @@ func TestLogFormat(t *testing.T) {
 	fakeErr := errors.New("this is a fake error")
 	el := l.WithError(fakeErr)
 	// Check if error key exists.
-	assert.Equal(t, el.fields["error"], fakeErr.Error())
+	assert.Equal(t, el.fields[0].V, fakeErr.Error())
 	el.Error("testing error")
 	assert.Contains(t, buf.String(), `level=error message="testing error" error="this is a fake error"`, "error log")
 	buf.Reset()
@@ -96,6 +96,6 @@ func TestLoggerConcurrency(t *testing.T) {
 
 func genLogs(l *Logger) {
 	for i := 0; i < 100; i++ {
-		l.WithFields(Fields{"index": strconv.FormatInt(int64(i), 10)}).Info("random log")
+		l.WithFields(F{"index", strconv.FormatInt(int64(i), 10)}).Info("random log")
 	}
 }


### PR DESCRIPTION
Benchstat:

```
name                      old time/op    new time/op    delta
NoField-8                    179ns ± 3%     182ns ± 7%     ~     (p=0.687 n=3+3)
OneField-8                   283ns ± 1%     214ns ± 5%  -24.39%  (p=0.008 n=3+3)
ThreeFields-8                338ns ± 2%     268ns ± 1%  -20.82%  (p=0.002 n=3+3)
ErrorField-8                 381ns ±13%     270ns ±11%  -29.14%  (p=0.029 n=3+3)
HugePayload-8               1.11µs ± 6%    0.69µs ± 2%  -37.92%  (p=0.004 n=3+3)
ThreeFields_WithCaller-8     932ns ± 4%     860ns ±13%     ~     (p=0.337 n=3+3)
NoField_WithColor-8          320ns ± 1%     298ns ±10%     ~     (p=0.316 n=3+3)
OneField_WithColor-8         441ns ± 9%     351ns ± 7%  -20.39%  (p=0.026 n=3+3)
ThreeFields_WithColor-8      569ns ±19%     419ns ± 1%     ~     (p=0.112 n=3+3)
ErrorField_WithColor-8       500ns ±10%     373ns ± 2%  -25.36%  (p=0.038 n=3+3)
HugePayload_WithColor-8     1.24µs ± 7%    0.88µs ± 8%  -28.93%  (p=0.003 n=3+3)

name                      old alloc/op   new alloc/op   delta
NoField-8                    0.00B          0.00B          ~     (zero variance)
OneField-8                    336B ± 0%       32B ± 0%     ~     (zero variance)
ThreeFields-8                 336B ± 0%       96B ± 0%     ~     (zero variance)
ErrorField-8                  368B ± 0%       80B ± 0%     ~     (zero variance)
HugePayload-8                 919B ± 0%      320B ± 0%     ~     (zero variance)
ThreeFields_WithCaller-8      656B ± 0%      416B ± 0%     ~     (zero variance)
NoField_WithColor-8          0.00B          0.00B          ~     (zero variance)
OneField_WithColor-8          336B ± 0%       32B ± 0%     ~     (zero variance)
ThreeFields_WithColor-8       336B ± 0%       96B ± 0%     ~     (zero variance)
ErrorField_WithColor-8        368B ± 0%       80B ± 0%     ~     (zero variance)
HugePayload_WithColor-8       919B ± 0%      320B ± 0%     ~     (zero variance)

name                      old allocs/op  new allocs/op  delta
NoField-8                     0.00           0.00          ~     (zero variance)
OneField-8                    2.00 ± 0%      1.00 ± 0%     ~     (zero variance)
ThreeFields-8                 2.00 ± 0%      1.00 ± 0%     ~     (zero variance)
ErrorField-8                  4.00 ± 0%      3.00 ± 0%     ~     (zero variance)
HugePayload-8                 3.00 ± 0%      1.00 ± 0%     ~     (zero variance)
ThreeFields_WithCaller-8      7.00 ± 0%      6.00 ± 0%     ~     (zero variance)
NoField_WithColor-8           0.00           0.00          ~     (zero variance)
OneField_WithColor-8          2.00 ± 0%      1.00 ± 0%     ~     (zero variance)
ThreeFields_WithColor-8       2.00 ± 0%      1.00 ± 0%     ~     (zero variance)
ErrorField_WithColor-8        4.00 ± 0%      3.00 ± 0%     ~     (zero variance)
HugePayload_WithColor-8       3.00 ± 0%      1.00 ± 0%     ~     (zero variance)
```