### PR TITLE
draft: fix: remove pointer receiver

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func BenchmarkNoField(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -21,8 +20,7 @@ func BenchmarkNoField(b *testing.B) {
 }
 
 func BenchmarkOneField(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -33,8 +31,7 @@ func BenchmarkOneField(b *testing.B) {
 }
 
 func BenchmarkThreeFields(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -50,8 +47,7 @@ func BenchmarkThreeFields(b *testing.B) {
 }
 
 func BenchmarkErrorField(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -65,8 +61,7 @@ func BenchmarkErrorField(b *testing.B) {
 }
 
 func BenchmarkHugePayload(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -89,8 +84,7 @@ func BenchmarkHugePayload(b *testing.B) {
 }
 
 func BenchmarkThreeFields_WithCaller(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	logger.SetCallerFrame(true, 3)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -107,8 +101,7 @@ func BenchmarkThreeFields_WithCaller(b *testing.B) {
 }
 
 func BenchmarkNoField_WithColor(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	logger.SetColorOutput(true)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -121,8 +114,7 @@ func BenchmarkNoField_WithColor(b *testing.B) {
 }
 
 func BenchmarkOneField_WithColor(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	logger.SetColorOutput(true)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -134,8 +126,7 @@ func BenchmarkOneField_WithColor(b *testing.B) {
 }
 
 func BenchmarkThreeFields_WithColor(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	logger.SetColorOutput(true)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -152,8 +143,7 @@ func BenchmarkThreeFields_WithColor(b *testing.B) {
 }
 
 func BenchmarkErrorField_WithColor(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	logger.SetColorOutput(true)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -168,8 +158,7 @@ func BenchmarkErrorField_WithColor(b *testing.B) {
 }
 
 func BenchmarkHugePayload_WithColor(b *testing.B) {
-	logger := logf.New()
-	logger.SetWriter(io.Discard)
+	logger := logf.New(io.Discard)
 	logger.SetColorOutput(true)
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"errors"
+	"os"
 	"time"
 
 	"github.com/zerodha/logf"
 )
 
 func main() {
-	logger := logf.New()
+	logger := logf.New(os.Stderr)
 
 	// Basic log.
 	logger.Info("starting app")

--- a/field_logger.go
+++ b/field_logger.go
@@ -4,31 +4,32 @@ import "os"
 
 type FieldLogger struct {
 	fields Fields
-	logger *Logger
+	logger Logger
 }
 
-func (l *FieldLogger) Debug(msg string) {
+// Debug emits a debug log line.
+func (l FieldLogger) Debug(msg string) {
 	l.logger.handleLog(msg, DebugLevel, l.fields)
 }
 
 // Info emits a info log line.
-func (l *FieldLogger) Info(msg string) {
+func (l FieldLogger) Info(msg string) {
 	l.logger.handleLog(msg, InfoLevel, l.fields)
 }
 
 // Warn emits a warning log line.
-func (l *FieldLogger) Warn(msg string) {
+func (l FieldLogger) Warn(msg string) {
 	l.logger.handleLog(msg, WarnLevel, l.fields)
 }
 
 // Error emits an error log line.
-func (l *FieldLogger) Error(msg string) {
+func (l FieldLogger) Error(msg string) {
 	l.logger.handleLog(msg, ErrorLevel, l.fields)
 }
 
 // Fatal emits a fatal level log line.
 // It aborts the current program with an exit code of 1.
-func (l *FieldLogger) Fatal(msg string) {
+func (l FieldLogger) Fatal(msg string) {
 	l.logger.handleLog(msg, ErrorLevel, l.fields)
 	os.Exit(1)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -3,6 +3,7 @@ package logf
 import (
 	"bytes"
 	"errors"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -37,7 +38,7 @@ func TestLevelParsing(t *testing.T) {
 }
 
 func TestNewLoggerDefault(t *testing.T) {
-	l := New()
+	l := New(os.Stderr)
 	assert.Equal(t, l.level, InfoLevel, "level is info")
 	assert.Equal(t, l.enableColor, false, "color output is disabled")
 	assert.Equal(t, l.enableCaller, false, "caller is disabled")
@@ -47,8 +48,7 @@ func TestNewLoggerDefault(t *testing.T) {
 
 func TestLogFormat(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New()
-	l.SetWriter(buf)
+	l := New(buf)
 	l.SetColorOutput(false)
 
 	// Info log.
@@ -79,8 +79,7 @@ func TestLogFormat(t *testing.T) {
 // These test are typically meant to be run with the data race detector.
 func TestLoggerConcurrency(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New()
-	l.SetWriter(buf)
+	l := New(buf)
 	l.SetColorOutput(false)
 
 	for _, n := range []int{10, 100, 1000} {
@@ -93,7 +92,7 @@ func TestLoggerConcurrency(t *testing.T) {
 	}
 }
 
-func genLogs(l *Logger) {
+func genLogs(l Logger) {
 	for i := 0; i < 100; i++ {
 		l.WithFields(Fields{"index": strconv.FormatInt(int64(i), 10)}).Info("random log")
 	}


### PR DESCRIPTION
Bench stat:

```
name                      old time/op    new time/op    delta
NoField-8                    179ns ± 3%     114ns ± 3%  -36.06%  (p=0.000 n=3+3)
OneField-8                   283ns ± 1%     244ns ± 3%  -13.69%  (p=0.009 n=3+3)
ThreeFields-8                338ns ± 2%     288ns ± 1%  -14.69%  (p=0.002 n=3+3)
ErrorField-8                 381ns ±13%     267ns ± 1%  -29.87%  (p=0.047 n=3+3)
HugePayload-8               1.11µs ± 6%    0.95µs ±21%     ~     (p=0.239 n=3+3)
ThreeFields_WithCaller-8     932ns ± 4%     405ns ± 2%  -56.57%  (p=0.001 n=3+3)
NoField_WithColor-8          320ns ± 1%     170ns ± 2%  -46.97%  (p=0.000 n=3+3)
OneField_WithColor-8         441ns ± 9%     323ns ± 3%  -26.79%  (p=0.023 n=3+3)
ThreeFields_WithColor-8      569ns ±19%     388ns ± 2%     ~     (p=0.081 n=3+3)
ErrorField_WithColor-8       500ns ±10%     350ns ± 2%  -30.00%  (p=0.027 n=3+3)
HugePayload_WithColor-8     1.24µs ± 7%    1.03µs ± 1%  -16.95%  (p=0.036 n=3+3)

name                      old alloc/op   new alloc/op   delta
NoField-8                    0.00B          0.00B          ~     (zero variance)
OneField-8                    336B ± 0%      336B ± 0%     ~     (zero variance)
ThreeFields-8                 336B ± 0%      336B ± 0%     ~     (zero variance)
ErrorField-8                  368B ± 0%      352B ± 0%     ~     (zero variance)
HugePayload-8                 919B ± 0%      919B ± 0%     ~     (zero variance)
ThreeFields_WithCaller-8      656B ± 0%      336B ± 0%     ~     (zero variance)
NoField_WithColor-8          0.00B          0.00B          ~     (zero variance)
OneField_WithColor-8          336B ± 0%      336B ± 0%     ~     (zero variance)
ThreeFields_WithColor-8       336B ± 0%      336B ± 0%     ~     (zero variance)
ErrorField_WithColor-8        368B ± 0%      352B ± 0%     ~     (zero variance)
HugePayload_WithColor-8       919B ± 0%      918B ± 0%     ~     (zero variance)

name                      old allocs/op  new allocs/op  delta
NoField-8                     0.00           0.00          ~     (zero variance)
OneField-8                    2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ThreeFields-8                 2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ErrorField-8                  4.00 ± 0%      3.00 ± 0%     ~     (zero variance)
HugePayload-8                 3.00 ± 0%      3.00 ± 0%     ~     (zero variance)
ThreeFields_WithCaller-8      7.00 ± 0%      2.00 ± 0%     ~     (zero variance)
NoField_WithColor-8           0.00           0.00          ~     (zero variance)
OneField_WithColor-8          2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ThreeFields_WithColor-8       2.00 ± 0%      2.00 ± 0%     ~     (zero variance)
ErrorField_WithColor-8        4.00 ± 0%      3.00 ± 0%     ~     (zero variance)
HugePayload_WithColor-8       3.00 ± 0%      3.00 ± 0%     ~     (zero variance)
```