### PR TITLE
specify options in New

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func BenchmarkNoField(b *testing.B) {
-	logger := logf.New(io.Discard)
+	logger := logf.New(logf.Opts{Writer: io.Discard})
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -20,7 +20,7 @@ func BenchmarkNoField(b *testing.B) {
 }
 
 func BenchmarkOneField(b *testing.B) {
-	logger := logf.New(io.Discard)
+	logger := logf.New(logf.Opts{Writer: io.Discard})
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -31,7 +31,7 @@ func BenchmarkOneField(b *testing.B) {
 }
 
 func BenchmarkThreeFields(b *testing.B) {
-	logger := logf.New(io.Discard)
+	logger := logf.New(logf.Opts{Writer: io.Discard})
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -45,7 +45,7 @@ func BenchmarkThreeFields(b *testing.B) {
 }
 
 func BenchmarkErrorField(b *testing.B) {
-	logger := logf.New(io.Discard)
+	logger := logf.New(logf.Opts{Writer: io.Discard})
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -59,7 +59,7 @@ func BenchmarkErrorField(b *testing.B) {
 }
 
 func BenchmarkHugePayload(b *testing.B) {
-	logger := logf.New(io.Discard)
+	logger := logf.New(logf.Opts{Writer: io.Discard})
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -82,8 +82,7 @@ func BenchmarkHugePayload(b *testing.B) {
 }
 
 func BenchmarkThreeFields_WithCaller(b *testing.B) {
-	logger := logf.New(io.Discard)
-	logger.SetCallerFrame(true, 3)
+	logger := logf.New(logf.Opts{Writer: io.Discard, CallerSkipFrameCount: 3, EnableCaller: true})
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -97,8 +96,7 @@ func BenchmarkThreeFields_WithCaller(b *testing.B) {
 }
 
 func BenchmarkNoField_WithColor(b *testing.B) {
-	logger := logf.New(io.Discard)
-	logger.SetColorOutput(true)
+	logger := logf.New(logf.Opts{Writer: io.Discard, EnableColor: true})
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -110,8 +108,7 @@ func BenchmarkNoField_WithColor(b *testing.B) {
 }
 
 func BenchmarkOneField_WithColor(b *testing.B) {
-	logger := logf.New(io.Discard)
-	logger.SetColorOutput(true)
+	logger := logf.New(logf.Opts{Writer: io.Discard, EnableColor: true})
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -122,8 +119,7 @@ func BenchmarkOneField_WithColor(b *testing.B) {
 }
 
 func BenchmarkThreeFields_WithColor(b *testing.B) {
-	logger := logf.New(io.Discard)
-	logger.SetColorOutput(true)
+	logger := logf.New(logf.Opts{Writer: io.Discard, EnableColor: true})
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -137,8 +133,7 @@ func BenchmarkThreeFields_WithColor(b *testing.B) {
 }
 
 func BenchmarkErrorField_WithColor(b *testing.B) {
-	logger := logf.New(io.Discard)
-	logger.SetColorOutput(true)
+	logger := logf.New(logf.Opts{Writer: io.Discard, EnableColor: true})
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -152,8 +147,7 @@ func BenchmarkErrorField_WithColor(b *testing.B) {
 }
 
 func BenchmarkHugePayload_WithColor(b *testing.B) {
-	logger := logf.New(io.Discard)
-	logger.SetColorOutput(true)
+	logger := logf.New(logf.Opts{Writer: io.Discard, EnableColor: true})
 	b.ReportAllocs()
 	b.ResetTimer()
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,23 +1,22 @@
 package main
 
 import (
-	"os"
 	"time"
 
 	"github.com/zerodha/logf"
 )
 
 func main() {
-	logger := logf.New(os.Stderr)
+	logger := logf.New(logf.Opts{
+		EnableColor:          true,
+		Level:                logf.DebugLevel,
+		CallerSkipFrameCount: 3,
+		EnableCaller:         true,
+		TimestampFormat:      time.RFC3339Nano,
+	})
 
-	// Basic log.
+	// Basic logs.
 	logger.Info("starting app")
-
-	// Enable colored output.
-	logger.SetColorOutput(true)
-
-	// Change verbosity on the fly.
-	logger.SetLevel(logf.DebugLevel)
 	logger.Debug("meant for debugging app")
 
 	// Add extra keys to the log.
@@ -25,11 +24,6 @@ func main() {
 
 	// Log with error key.
 	logger.Error("error fetching details", "error", "this is a dummy error")
-
-	// Enable `caller` field in the log and specify the number of frames to skip to get the caller.
-	logger.SetCallerFrame(true, 3)
-	// Change the default timestamp format.
-	logger.SetTimestampFormat(time.RFC3339Nano)
 
 	// Log the error and set exit code as 1.
 	logger.Fatal("goodbye world")

--- a/log_test.go
+++ b/log_test.go
@@ -3,7 +3,6 @@ package logf
 import (
 	"bytes"
 	"errors"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -38,18 +37,17 @@ func TestLevelParsing(t *testing.T) {
 }
 
 func TestNewLoggerDefault(t *testing.T) {
-	l := New(os.Stderr)
-	assert.Equal(t, l.level, InfoLevel, "level is info")
-	assert.Equal(t, l.enableColor, false, "color output is disabled")
-	assert.Equal(t, l.enableCaller, false, "caller is disabled")
-	assert.Equal(t, l.callerSkipFrameCount, 0, "skip frame count is 0")
-	assert.Equal(t, l.tsFormat, defaultTSFormat, "timestamp format is default")
+	l := New(Opts{})
+	assert.Equal(t, l.Opts.Level, InfoLevel, "level is info")
+	assert.Equal(t, l.Opts.EnableColor, false, "color output is disabled")
+	assert.Equal(t, l.Opts.EnableCaller, false, "caller is disabled")
+	assert.Equal(t, l.Opts.CallerSkipFrameCount, 0, "skip frame count is 0")
+	assert.Equal(t, l.Opts.TimestampFormat, defaultTSFormat, "timestamp format is default")
 }
 
 func TestLogFormat(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New(buf)
-	l.SetColorOutput(false)
+	l := New(Opts{Writer: buf})
 
 	// Info log.
 	l.Info("hello world")
@@ -70,8 +68,7 @@ func TestLogFormat(t *testing.T) {
 
 func TestOddNumberedFields(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New(buf)
-	l.SetColorOutput(false)
+	l := New(Opts{Writer: buf})
 
 	// Give a odd number of fields.
 	l.Info("hello world", "key1", "val1", "key2")
@@ -82,8 +79,7 @@ func TestOddNumberedFields(t *testing.T) {
 // These test are typically meant to be run with the data race detector.
 func TestLoggerConcurrency(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New(buf)
-	l.SetColorOutput(false)
+	l := New(Opts{Writer: buf})
 
 	for _, n := range []int{10, 100, 1000} {
 		wg := sync.WaitGroup{}


### PR DESCRIPTION
    - Removes the .Set() method for logger.
    - Specify opts in .New() for initialising logger.
    - Reduce allocs while getting caller frame count.

cc @iamd3vil 