### PR TITLE
feat: Change any to interface{} to support Go 1.17.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,17 +3,17 @@ name: build
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
 
 jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.18]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go-version: [~1.17, ~1.18]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,7 +31,7 @@ func BenchmarkOneField(b *testing.B) {
 }
 
 func BenchmarkOneFieldWithDefaultFields(b *testing.B) {
-	logger := logf.New(logf.Opts{Writer: io.Discard, DefaultFields: []any{"component", "logf"}})
+	logger := logf.New(logf.Opts{Writer: io.Discard, DefaultFields: []interface{}{"component", "logf"}})
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {

--- a/examples/main.go
+++ b/examples/main.go
@@ -13,7 +13,7 @@ func main() {
 		CallerSkipFrameCount: 3,
 		EnableCaller:         true,
 		TimestampFormat:      time.RFC3339Nano,
-		DefaultFields:        []any{"scope", "example"},
+		DefaultFields:        []interface{}{"scope", "example"},
 	})
 
 	// Basic logs.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zerodha/logf
 
-go 1.18
+go 1.17
 
 require github.com/stretchr/testify v1.8.0
 

--- a/log.go
+++ b/log.go
@@ -32,7 +32,7 @@ type Opts struct {
 	CallerSkipFrameCount int
 
 	// These fields will be printed with every log.
-	DefaultFields []any
+	DefaultFields []interface{}
 }
 
 // Logger is the interface for all log operations
@@ -141,35 +141,35 @@ func (l Level) String() string {
 }
 
 // Debug emits a debug log line.
-func (l Logger) Debug(msg string, fields ...any) {
+func (l Logger) Debug(msg string, fields ...interface{}) {
 	l.handleLog(msg, DebugLevel, fields...)
 }
 
 // Info emits a info log line.
-func (l Logger) Info(msg string, fields ...any) {
+func (l Logger) Info(msg string, fields ...interface{}) {
 	l.handleLog(msg, InfoLevel, fields...)
 }
 
 // Warn emits a warning log line.
-func (l Logger) Warn(msg string, fields ...any) {
+func (l Logger) Warn(msg string, fields ...interface{}) {
 	l.handleLog(msg, WarnLevel, fields...)
 }
 
 // Error emits an error log line.
-func (l Logger) Error(msg string, fields ...any) {
+func (l Logger) Error(msg string, fields ...interface{}) {
 	l.handleLog(msg, ErrorLevel, fields...)
 }
 
 // Fatal emits a fatal level log line.
 // It aborts the current program with an exit code of 1.
-func (l Logger) Fatal(msg string, fields ...any) {
+func (l Logger) Fatal(msg string, fields ...interface{}) {
 	l.handleLog(msg, FatalLevel, fields...)
 	exit()
 }
 
 // handleLog emits the log after filtering log level
 // and applying formatting of the fields.
-func (l Logger) handleLog(msg string, lvl Level, fields ...any) {
+func (l Logger) handleLog(msg string, lvl Level, fields ...interface{}) {
 	// Discard the log if the verbosity is higher.
 	// For eg, if the lvl is `3` (error), but the incoming message is `0` (debug), skip it.
 	if lvl < l.Opts.Level {
@@ -194,7 +194,7 @@ func (l Logger) handleLog(msg string, lvl Level, fields ...any) {
 		count      int
 		fieldCount = len(l.DefaultFields) + len(fields)
 		key        string
-		val        any
+		val        interface{}
 	)
 
 	// If there are odd number of fields, ignore the last.
@@ -294,7 +294,7 @@ func writeCallerToBuf(buf *byteBuffer, key string, depth int, lvl Level, color, 
 }
 
 // writeToBuf takes key, value and additional options to write to the buffer in logfmt.
-func writeToBuf(buf *byteBuffer, key string, val any, lvl Level, color, space bool) {
+func writeToBuf(buf *byteBuffer, key string, val interface{}, lvl Level, color, space bool) {
 	if color {
 		escapeAndWriteString(buf, getColoredKey(key, lvl))
 	} else {
@@ -338,7 +338,7 @@ func writeToBuf(buf *byteBuffer, key string, val any, lvl Level, color, space bo
 	}
 }
 
-// escapeAndWriteString escapes the string if any unwanted chars are there.
+// escapeAndWriteString escapes the string if interface{} unwanted chars are there.
 func escapeAndWriteString(buf *byteBuffer, s string) {
 	idx := strings.IndexFunc(s, checkEscapingRune)
 	if idx != -1 || s == "null" {

--- a/log_test.go
+++ b/log_test.go
@@ -144,7 +144,7 @@ func TestLoggerTypes(t *testing.T) {
 
 func TestLogFormatWithDefaultFields(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New(Opts{Writer: buf, DefaultFields: []any{"defaultkey", "defaultvalue"}})
+	l := New(Opts{Writer: buf, DefaultFields: []interface{}{"defaultkey", "defaultvalue"}})
 
 	l.Info("hello world")
 	require.Contains(t, buf.String(), `level=info message="hello world" defaultkey=defaultvalue`)
@@ -225,7 +225,7 @@ func TestOddNumberedFields(t *testing.T) {
 
 func TestOddNumberedFieldsWithDefaultFields(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New(Opts{Writer: buf, DefaultFields: []any{
+	l := New(Opts{Writer: buf, DefaultFields: []interface{}{
 		"defaultkey", "defaultval",
 	}})
 


### PR DESCRIPTION
Currently `logf` fails to compile on Go 1.17 due to using `any` in place of `interface{}`. I think there's no technical reason to not support 1.17 until it reaches end of life.

We can change this to `any` once `1.17` reaches end of life.